### PR TITLE
Add SSH-MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Tools for executing commands or interacting with local environments safely.
 |------|-------|
 | [MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server) | Secure CLI execution with policies. |
 | [g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands) | Run commands and scripts via MCP. |
+| [Harsh-2002/SSH-MCP](https://github.com/Harsh-2002/SSH-MCP) | Remote SSH/SFTP with 43 tools: Docker, monitoring, databases, file ops, VoIP diagnostics, jump host support. |
 | [tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server) | Shell command execution server. |
 | [ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp) | iTerm integration for macOS. |
 | [OthmaneBlial/term_mcp_deepseek](https://github.com/OthmaneBlial/term_mcp_deepseek) | Terminal server for DeepSeek. |


### PR DESCRIPTION
## Summary

Adds SSH-MCP server to the Command Line & Local Ops section.

## Server Details

- **Repo**: https://github.com/Harsh-2002/SSH-MCP
- **Docker**: `firstfinger/ssh-mcp:latest`
- **Language**: Go 1.25+
- **License**: MIT
- **Transport**: stdio + HTTP

## Key Features

- 43 production tools covering SSH, SFTP, Docker, monitoring, databases, and VoIP
- Persistent SSH sessions with connection pooling
- Jump host/bastion support via `via` parameter
- Server-side syntax validation (YAML, JSON, TOML, XML, INI, Dockerfile, ENV)
- Sed-like file editing capabilities
- Single static binary (11MB), multi-architecture (AMD64/ARM64)

## Why It's Useful for DevOps

Enables AI agents to manage remote Linux infrastructure, execute commands, transfer files between hosts, manage Docker containers, query databases, and perform comprehensive system diagnostics via persistent SSH connections.