### PR TITLE
Add wopee-mcp to Browser Automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Tools for executing commands or interacting with local environments safely.
 | [kimtth/mcp-aoai-web-browsing](https://github.com/kimtth/mcp-aoai-web-browsing) | Web browsing MCP server. |
 | [scrapeless-ai/scrapeless-mcp-server](https://github.com/scrapeless-ai/scrapeless-mcp-server) | SERP and web data access. |
 | [getrupt/ashra-mcp](https://github.com/getrupt/ashra-mcp) | Browser automation server. |
+| [autonomous-testing/wopee-mcp](https://www.npmjs.com/package/wopee-mcp) | AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status. |
 
 ## ⚙️ Code Execution
 


### PR DESCRIPTION
## Summary

Adds [wopee-mcp](https://www.npmjs.com/package/wopee-mcp) to the Browser Automation section, alongside existing entries like `executeautomation/playwright-mcp-server` and `microsoft/playwright-mcp`.

- **npm**: `npx wopee-mcp@latest`
- **What it does**: AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.
- **Language**: TypeScript

## Checklist

- Entry follows existing table row format
- Link points to the npm package page (GitHub repo is private)
- Relevant to DevOps browser automation / web testing workflows