### PR TITLE
Add Not Human Search to Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Tools for executing commands or interacting with local environments safely.
 | [waystation-ai/mcp](https://github.com/waystation-ai/mcp) | Connect MCP hosts to apps. |
 | [sxhxliang/mcp-access-point](https://github.com/sxhxliang/mcp-access-point) | One-click MCP wrapper. |
 | [Arch Tools](https://archtools.dev) | 53 production-ready AI tools via MCP with x402 USDC payments. |
+| [Not Human Search](https://nothumansearch.ai/mcp) | Search engine indexing 1,900+ agent-first tools (MCP servers, OpenAPI, llms.txt). Tools for `search_sites`, `verify_mcp` (live JSON-RPC probe), `list_categories`, and more. |
 
 ## 🚀 CI/CD
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai/mcp) to the Aggregators section.

NHS is a search engine for agent-first tools — indexes 1,900+ MCP servers, OpenAPI specs, and llms.txt endpoints, scored by agentic readiness. Fits alongside `pluggedin-mcp-proxy` and `mcpmcp-server` as a discovery-time layer: agents use it to find MCP servers for a given DevOps stack (e.g., "find MCP servers for Kubernetes" or "list Postgres MCP servers with llms.txt").

Key tools exposed:
- `search_sites` — tsvector-ranked search across indexed agent tools
- `verify_mcp` — live JSON-RPC probe (initialize + tools/list) that validates a URL actually implements MCP before wiring in
- `list_categories`, `get_top_sites`, `check_url`, and 6 more

Available as MCP server at `/mcp` (JSON-RPC 2.0, streamable-http) and REST API at `/api/v1`. Public, free, no login.

Wire in:
```
claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp
```