### PR TITLE
Add Uptrack MCP to APM & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ AWS also provides a [Prometheus MCP Server](https://awslabs.github.io/mcp/server
 |------|-------|
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | Dynatrace monitoring integration. |
 | [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 observability. |
+| [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring — 10 tools for monitor/incident management. Remote MCP (OAuth 2.0) + stdio. |
 
 ## 🔒 Security
 


### PR DESCRIPTION
Adds [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) to APM & Monitoring.

Uptrack MCP exposes 10 tools for managing uptime monitors and incidents from AI assistants (list/get/create/update/pause/resume/delete monitor, list/get/acknowledge incident).

**Transports**: Remote Streamable-HTTP at `https://api.uptrack.app/mcp` (OAuth 2.0 + PKCE) or stdio via `npx @uptrack-app/mcp` with API key.

Published on [npm](https://www.npmjs.com/package/@uptrack-app/mcp) and [GitHub](https://github.com/Uptrack-App/uptrack-mcp) under MIT.