### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Multi-tool support.
 | [weibaohui/k8m](https://github.com/weibaohui/k8m) | Multi-cluster management + UI. |
 | [weibaohui/kom](https://github.com/weibaohui/kom) | SDK + multi-cluster operations. |
 | [wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye) | Cluster health analysis and ops. |
-| [kubestellar/console](https://github.com/kubestellar/console) | AI-powered multi-cluster management dashboard with MCP server (kc-agent) for AI-assisted operations. |
+| [kubestellar/console](https://github.com/kubestellar/console) | Multi-cluster dashboard + MCP server (Go). AI-assisted ops across edge & cloud. |
 
 ### Tilt
 


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the **Community Kubernetes servers** table.

KubeStellar Console is a multi-cluster Kubernetes dashboard with a built-in MCP server (`kc-agent`) written in Go. It bridges kubeconfig contexts to LLMs for AI-assisted operations across edge and cloud clusters.

- **Repo:** https://github.com/kubestellar/console
- **Language:** Go
- **License:** Apache-2.0
- **CNCF Sandbox project**