### PR TITLE
Add dakera-mcp to Coding Agents — self-hosted MCP memory for DevOps agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Tools for executing commands or interacting with local environments safely.
 | [doggybee/mcp-server-leetcode](https://github.com/doggybee/mcp-server-leetcode) | LeetCode problem access. |
 | [jinzcdev/leetcode-mcp-server](https://github.com/jinzcdev/leetcode-mcp-server) | LeetCode (global/China) access. |
 | [willibrandon/CursorMCPMonitor](https://github.com/willibrandon/CursorMCPMonitor) | MCP monitoring for Cursor. |
+| [dakera-ai/dakera-mcp](https://github.com/dakera-ai/dakera-mcp) | Self-hosted MCP-native agent memory server. 83 tools for persistent, decay-weighted memory across DevOps agent sessions. RocksDB + HNSW, 87.8% LoCoMo benchmark. |
 | [SKULLFIRE07/cortex-memory](https://github.com/SKULLFIRE07/cortex-memory) | Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. VSCode extension + CLI + MCP server. |
 | [claw-army/claude-node](https://github.com/claw-army/claude-node) | Python subprocess bridge for Claude Code CLI. |
 | [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy) | Spec-driven dev companion with persistent memory, adaptive change pipeline, and Clarity Gate. 32 tools, single Go binary. |


### PR DESCRIPTION
## dakera-mcp

[dakera-mcp](https://github.com/dakera-ai/dakera-mcp) is a self-hosted MCP-native agent memory server.

Adding to the Coding Agents section alongside cortex-memory and Hoofy since it provides the persistent memory layer that coding and DevOps agents need to function across sessions.

**Key differentiator — production-grade server architecture:**
- Not just a single-agent memory tool — a full server with multi-namespace isolation for teams
- 83 MCP tools: store, recall, forget, search, configure decay, manage sessions/namespaces
- Decay-weighted recall: memory fades over time, preventing context pollution from stale operational data
- Self-hosted on your infrastructure, RocksDB + HNSW vector search
- 87.8% LoCoMo benchmark, multi-SDK (Python/JS/Rust/Go)
- Docker Compose via https://github.com/dakera-ai/dakera-deploy