### PR TITLE
Add click-to-mcp: auto-wrap Click/typer CLIs as MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ GitOps deployment management via AI.
 | Repo | Notes |
 |------|-------|
 | [Acid-base/FastMCP-Proper](https://github.com/Acid-base/FastMCP-Proper) | MCP server with CI/CD tooling. |
+| [Coding-Dev-Tools/click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) 🐍 | Auto-wrap any Click/typer Python CLI as an MCP server with zero code changes. |
 | [lobehub/mcp-hello-world](https://github.com/lobehub/mcp-hello-world) | CI/CD test server. |
 
 ### Build Tools


### PR DESCRIPTION
### Description

Add [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the CI/CD Helpers section.

**click-to-mcp** auto-wraps any Click/typer Python CLI as an MCP server with zero code changes. This is particularly useful in DevOps CI/CD contexts where existing CLI tools can be instantly exposed as MCP servers for AI coding agents.

Part of the [Revenue Holdings](https://coding-dev-tools.github.io/revenueholdings.dev/) developer tool ecosystem.

### Checklist
- [x] The project is actively maintained
- [x] The project is directly relevant to DevOps workflows
- [x] Entry follows the existing table format