### PR TITLE
Add PGYER (蒲公英) official MCP server — Mobile Beta Distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,14 @@ GitOps deployment management via AI.
 | **Maintainer** | 👥 Community |
 | **What it does** | Mobile CI/CD pipeline control. |
 
+### PGYER (Mobile Beta Distribution)
+
+| | |
+|---|---|
+| **Repo** | [PGYER/pgyer-mcp-server](https://github.com/PGYER/pgyer-mcp-server) |
+| **Maintainer** | 🎖️ Official ([PGYER](https://www.pgyer.com), operating since 2014) |
+| **What it does** | Upload iOS / Android / HarmonyOS builds (`.ipa` / `.apk` / `.hap`) to PGYER (蒲公英), China's leading mobile app beta-distribution platform. Fetch install links, QR codes, and version metadata from CI/CD. Published on npm as `pgyer-mcp-server`. |
+
 ### DevOps Visibility
 
 | Repo | Notes |


### PR DESCRIPTION
## Summary

Adds **PGYER/pgyer-mcp-server** as a new \"PGYER (Mobile Beta Distribution)\" subsection, placed alongside Codemagic in the CI/CD section. PGYER fills the \"distribute beta build to testers\" stage that comes after Codemagic-style build orchestration.

## What it is

Vendor-official MCP server from [PGYER (蒲公英)](https://www.pgyer.com), China's leading mobile app beta-distribution platform. PGYER has operated since **2014** (12+ years), used by hundreds of thousands of mobile developers — China's equivalent of TestFlight / Firebase App Distribution.

Published on npm as [\`pgyer-mcp-server\`](https://www.npmjs.com/package/pgyer-mcp-server) and lives in the official \`PGYER/\` GitHub organization.

## Tooling

- \`upload-app\` — upload \`.ipa\` / \`.apk\` / \`.hap\` from CI/CD agents
- \`list-my-apps\` — enumerate beta apps owned by the API key
- \`get-app-info-by-shortcut\` — fetch install link / QR / build metadata

## Requirements check

- 🔗 Working public link: https://github.com/PGYER/pgyer-mcp-server ✅
- 🔧 DevOps relevance: CI/CD beta-distribution stage ✅
- 🔄 Active maintenance: vendor-owned official repo; last push 2025-11. The skill companion [\`PGYER/pgyer-skill\`](https://github.com/PGYER/pgyer-skill) ships v0.3.0 in the same week as this PR — both are part of one published release wave. PGYER maintains the underlying API as a production product.

## Test plan

- [x] Repository link resolves
- [x] Follows the \"subsection + 2-column table\" format used by Codemagic
- [x] Placed contextually (right after Codemagic — both are mobile-distribution-adjacent)