### PR TITLE
feat: add TWZRD Agent Intel MCP to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Vulnerability scanning directly from your AI assistant.
 | [slouchd/cyberchef-api-mcp-server](https://github.com/slouchd/cyberchef-api-mcp-server) | CyberChef API access. |
 | [nickpending/mcp-recon](https://github.com/nickpending/mcp-recon) | Recon + domain analysis. |
 | [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) | AES-256-GCM + Argon2id encrypted vault. Resolves `{{PLACEHOLDER}}` secrets so API keys never appear in prompts. |
+| [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final) | **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native trust scoring MCP server for AI agents. Free preflight trust assessment + paid signed V5 x402 receipts via https://intel.twzrd.xyz |
 
 ## 📝 Collaboration
 

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Vulnerability scanning directly from your AI assistant.
 | [slouchd/cyberchef-api-mcp-server](https://github.com/slouchd/cyberchef-api-mcp-server) | CyberChef API access. |
 | [nickpending/mcp-recon](https://github.com/nickpending/mcp-recon) | Recon + domain analysis. |
 | [Agnuxo1/EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) | AES-256-GCM + Argon2id encrypted vault. Resolves `{{PLACEHOLDER}}` secrets so API keys never appear in prompts. |
-| [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final) | **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native trust scoring MCP server for AI agents. Free preflight trust assessment + paid signed V5 x402 receipts via https://intel.twzrd.xyz |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Trust infrastructure MCP server for AI agents on Solana. On-chain agent identity, trust scoring, pre-dispatch gating, and signed V5 receipts. 4 free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. Paid `get_trust_receipt` via x402 (<$0.01 USDC). Zero-install: `https://intel.twzrd.xyz/mcp`. |
 
 ## 📝 Collaboration
 

--- a/README.md
+++ b/README.md
@@ -502,6 +502,12 @@ AWS also provides a [Prometheus MCP Server](https://awslabs.github.io/mcp/server
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | Dynatrace monitoring integration. |
 | [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 observability. |
 | [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring — 10 tools for monitor/incident management. Remote MCP (OAuth 2.0) + stdio. |
+### Agent Identity & Trust
+
+| Server | Description |
+|------|-------|
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Agent wallet trust scoring for DevOps pipelines. Verify AI agent identity before granting production access or logging agent actions. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` |
+
 
 ## 🔒 Security
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) as a new "Agent Identity & Trust" subsection under Observability.

In DevOps/SRE multi-agent pipelines, knowing which AI agent is taking an action is critical for audit trails and accountability. TWZRD Agent Intel is a zero-install MCP server that provides agent wallet trust scoring on Solana.

- **MCP endpoint**: `https://intel.twzrd.xyz/mcp` (streamable-http, no install needed)
- **Free tools**: `score_agent(wallet)`, `preflight_check(wallet)`
- **Paid**: `get_trust_receipt(wallet)` via x402 micropayment for audit-grade receipts
- **Config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`