### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP aggregator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Tools for executing commands or interacting with local environments safely.
 | [sxhxliang/mcp-access-point](https://github.com/sxhxliang/mcp-access-point) | One-click MCP wrapper. |
 | [Arch Tools](https://archtools.dev) | 53 production-ready AI tools via MCP with x402 USDC payments. |
 | [Not Human Search](https://nothumansearch.ai/mcp) | Search engine indexing 1,900+ agent-first tools (MCP servers, OpenAPI, llms.txt). Tools for `search_sites`, `verify_mcp` (live JSON-RPC probe), `list_categories`, and more. |
+| [The Stall](https://the-stall.intuitek.ai/mcp) | 208 pay-per-call data capabilities via x402 USDC micropayments — market intel, crypto/DeFi analytics, infrastructure probes, financial data, and more. No API keys. |
 
 ## 🚀 CI/CD
 


### PR DESCRIPTION
## Add The Stall — 210 pay-per-call AI data capabilities via x402 (MCP)

**The Stall** is a production remote MCP server offering 210 pay-per-call data capabilities via x402 USDC micropayments on Base. It fits the **Aggregators** section alongside Arch Tools and Not Human Search — all three are x402-native services with no API keys required.

### Why it fits DevOps workflows

The Stall includes infrastructure-relevant capabilities:
- , , , ,  — endpoint and domain probes
- , ,  — infrastructure intelligence
-  — repo health, release status, maintenance signals
- Market and financial data — useful for cost modeling, vendor evaluation, infrastructure spend analysis

### Entry added

Placed at the end of the Aggregators table, after Arch Tools and Not Human Search.

### Service details
- **MCP endpoint:** https://the-stall.intuitek.ai/mcp
- **Health:** https://the-stall.intuitek.ai/health (returns , lists all 208 caps)
- **Payment:** USDC on Base mainnet via x402 — no API keys, no accounts
- **Version:** v4.64.0 | Live since early 2026 | Source: https://github.com/thebrierfox/the-stall
