### PR TITLE
Add Xquik DevOps observability entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,9 @@ AWS also provides a [Prometheus MCP Server](https://awslabs.github.io/mcp/server
 | Repo | Notes |
 |------|-------|
 | [dynatrace-oss/dynatrace-mcp](https://github.com/dynatrace-oss/dynatrace-mcp) | Dynatrace monitoring integration. |
-| [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 observability. |
-| [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring — 10 tools for monitor/incident management. Remote MCP (OAuth 2.0) + stdio. |
+| [last9/last9-mcp-server](https://github.com/last9/last9-mcp-server) | Last9 APM, logs, and incident context for SRE workflows. |
+| [Uptrack-App/uptrack-mcp](https://github.com/Uptrack-App/uptrack-mcp) | Uptime monitoring with 10 tools for monitor and incident management. Remote MCP (OAuth 2.0) plus stdio. |
+| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter monitoring for release feedback, incident signals, brand mentions, and account activity. |
 
 ## 🔒 Security
 


### PR DESCRIPTION
## Summary

- Adds Xquik to the Observability APM & Monitoring list for release feedback, incident signals, brand mentions, and account activity monitoring.
- Clarifies the Last9 note so readers can see its APM, log, and incident workflow fit.
- Clarifies the Uptrack note by spelling out monitor and incident management support and transport options.

## Validation

- `git diff --check`
- Checked the Last9, Uptrack, and Xquik links touched by this patch.
